### PR TITLE
Removal of unused import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ import subprocess
 import sys
 import sysconfig
 from contextlib import contextmanager
-from setuptools import Extension, setup
+from setuptools import setup
 from cy_build import CyExtension as Extension, cy_build_ext as build_ext
 try:
     import cython


### PR DESCRIPTION
Import is overwritten in the next line with cy_build